### PR TITLE
added decimal setting converter

### DIFF
--- a/NFig/SettingConverterAttribute.cs
+++ b/NFig/SettingConverterAttribute.cs
@@ -96,6 +96,12 @@ namespace NFig
         public double GetValue(string s) { return double.Parse(s); }
     }
 
+	public class DecimalSettingConverter: ISettingConverter<decimal>
+	{
+		public string GetString(decimal value) { return value.ToString(); }
+		public decimal GetValue(string s) { return decimal.Parse(s); }
+	}
+
     #endregion
 
     #region TextConverters

--- a/NFig/SettingsFactory.cs
+++ b/NFig/SettingsFactory.cs
@@ -34,6 +34,7 @@ namespace NFig
             {typeof(double), new DoubleSettingConverter()},
             {typeof(string), new StringSettingConverter()},
             {typeof(char), new CharSettingConverter()},
+            {typeof(decimal), new DecimalSettingConverter()}
         };
 
         public SettingsFactory(Dictionary<Type, SettingConverterAttribute> additionalDefaultConverters = null)


### PR DESCRIPTION
Love the lib. Was getting exceptions when using decimal properties with setting attribute.

`No default converter is available for setting {PropertyName} of type Decimal`
